### PR TITLE
readme.md : Updated cloning url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ go-HoneyPot listens on specified ports for any communication. When an attacker a
 
 ## Running go-HoneyPot
 
-1. `git clone git@github.com:Mojachieee/go-HoneyPot.git`
+1. `git clone https://github.com/Mojachieee/go-HoneyPot`
 2. `cd go-HoneyPot`
 3. `go get`
 


### PR DESCRIPTION
Cloning the previous url would cause this error 
```
Cloning into 'go-HoneyPot'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Changing the url to clone over HTTPS avoids this error. 